### PR TITLE
es_wpv.vdpv_detection_timeliness function

### DIFF
--- a/R/es_sample_shipment_timeliness.R
+++ b/R/es_sample_shipment_timeliness.R
@@ -1,0 +1,80 @@
+#' #' Timeliness of ES Shipment
+#' @description Days between ES sample collection and lab receipt of shipped samples (Target: 3 days for Domestic Labs and 7 days for International Labs)
+#' @param es_data,region,country,year,group_by,end_date Data frame and optional filters: region(s), country(ies), year(s) (single year for starting year or range), grouping (group by = ""), and reference date (default Sys.Date())
+#' @return Grouped tibble with lab receipt timeliness and median as of current month per year
+es_sample_shipment_timeliness <- function(es_data, region = NULL, country = NULL, year = NULL, group_by = NULL, end_date = Sys.Date()) {
+  # Apply filters
+  if(!is.null(region)) es_data <- es_data |> dplyr::filter(toupper(trimws(who.region)) %in% toupper(trimws(region)))
+  if(!is.null(country)) es_data <- es_data |> dplyr::filter(toupper(trimws(ADM0_NAME)) %in% toupper(trimws(country)))
+
+  # Determine years and filter
+  available_years <- unique(lubridate::year(es_data$collection.date))
+  current_year <- lubridate::year(end_date)
+  if(!is.null(year)) {requested_years <- if(length(year) == 1) year:current_year else year
+    years_to_use <- intersect(requested_years, available_years)}
+  else {years_to_use <- available_years}
+
+  es_data <- es_data |> dplyr::filter(lubridate::year(collection.date) %in% years_to_use)
+  if(nrow(es_data) == 0) {message("* No data available for the selected year(s) and location. Change filtering parameters or default to process all available data.")
+    return(dplyr::tibble())}
+
+  # Data validation and lab type processing
+  total_samples <- nrow(es_data)
+  both_dates_available <- sum(!is.na(es_data$collection.date) & !is.na(es_data$date.received.in.lab))
+  invalid_records <- sum(as.Date(es_data$date.received.in.lab) < as.Date(es_data$collection.date), na.rm = TRUE)
+
+  valid_data <- es_data |>
+    dplyr::filter(!is.na(collection.date) & !is.na(date.received.in.lab) & as.Date(date.received.in.lab) >= as.Date(collection.date)) |>
+    dplyr::mutate(
+      days_to_lab_receipt = as.numeric(as.Date(date.received.in.lab) - as.Date(collection.date)),
+      year = lubridate::year(collection.date),
+      lab_type = case_when(tolower(trimws(es.lab.type)) == "in-country" ~ "domestic_lab", tolower(trimws(es.lab.type)) == "international" ~ "international_lab", TRUE ~ "no.es.lab.type"),
+      target_days = ifelse(lab_type == "domestic_lab", 3, 7),
+      meets_target = ifelse(lab_type == "no.es.lab.type", NA, days_to_lab_receipt <= target_days))
+
+  domestic_count <- sum(valid_data$lab_type == "domestic_lab"); international_count <- sum(valid_data$lab_type == "international_lab"); no_lab_type_count <- sum(valid_data$lab_type == "no.es.lab.type")
+  has_no_lab_types <- no_lab_type_count > 0
+
+  # Conditional quality messaging
+  if(total_samples != both_dates_available || invalid_records > 0 || has_no_lab_types) {
+    message(paste("* Data quality: Total ES Samples =", total_samples, "| Data with Collection and Lab receipt dates =", both_dates_available, "| Invalid Data (Lab receipt < Collection) =", invalid_records, "|| Valid Data Lab Type: Domestic =", domestic_count, "| International =", international_count, "| No Lab Type =", no_lab_type_count))}
+
+  # Determine grouping
+  group_vars <- if(isTRUE(group_by == "region")) c("who.region", "year") else if(isTRUE(group_by == "country")) c("who.region", "ADM0_NAME", "year") else if(!is.null(region) && is.null(group_by)) c("who.region", "year") else c("who.region", "ADM0_NAME", "year")
+
+  # Calculate ES lab receipt timeliness results
+  result <- valid_data |>
+    dplyr::group_by(dplyr::across(dplyr::all_of(group_vars))) |>
+    dplyr::summarise(
+      valid_es_samples = n(),
+      valid_with_lab_type = sum(!is.na(meets_target)),
+      lab_receipt_within_target = sum(meets_target, na.rm = TRUE),
+      pct_lab_receipt_within_target = ifelse(sum(!is.na(meets_target)) == 0, NA, round(lab_receipt_within_target / sum(!is.na(meets_target)) * 100, 1)),
+      valid_with_no_lab_type_data = if(has_no_lab_types) sum(lab_type == "no.es.lab.type") else NULL,
+      pct_no_lab_type_within_3days = if(has_no_lab_types) ifelse(sum(lab_type == "no.es.lab.type") == 0, NA, round(sum(lab_type == "no.es.lab.type" & days_to_lab_receipt <= 3, na.rm = TRUE) / sum(lab_type == "no.es.lab.type") * 100, 1)) else NULL,
+      pct_no_lab_type_within_7days = if(has_no_lab_types) ifelse(sum(lab_type == "no.es.lab.type") == 0, NA, round(sum(lab_type == "no.es.lab.type" & days_to_lab_receipt <= 7, na.rm = TRUE) / sum(lab_type == "no.es.lab.type") * 100, 1)) else NULL,
+      .groups = "keep")
+
+  # Calculate median up to current month for each year
+  current_month <- lubridate::month(end_date)
+  median_column_name <- paste0("Median Days Taken (Jan-", month.abb[current_month], ")")
+
+  median_df <- valid_data |>
+    dplyr::filter(lubridate::year(collection.date) != current_year |
+                    (lubridate::year(collection.date) == current_year & lubridate::month(collection.date) <= current_month)) |>
+    dplyr::group_by(dplyr::across(dplyr::all_of(group_vars))) |>
+    dplyr::summarise(!!median_column_name := round(median(days_to_lab_receipt, na.rm = TRUE), 1),
+                     .groups = "drop")
+
+  result <- dplyr::left_join(result, median_df, by = group_vars)
+
+  # Result for selection
+  result <- result |>
+    dplyr::select_if(~ !all(is.null(.))) |>
+    dplyr::mutate(year = ifelse(year == current_year, paste0(year, "*"), as.character(year))) |>
+    dplyr::rename_with(~ case_when(. == "who.region" ~ "region", . == "ADM0_NAME" ~ "country", TRUE ~ .))
+
+  if(current_year %in% years_to_use) message(paste0("* Note: ", current_year, " is still in progress..."))
+  message("* ES samples lab receipt timeliness (in-country: 3 days, international: 7 days)")
+  result |> print(width = Inf)
+}

--- a/R/es_wpv.vdpv_detection_timeliness.R
+++ b/R/es_wpv.vdpv_detection_timeliness.R
@@ -1,0 +1,89 @@
+#' Timeliness of WPV/VDPV Detection from ES Samples
+#' @description Days between ES sample collection and final laboratory result for WPV/VDPV positive ES samples (Targets: 35 days for full capacity labs, 46 days for limited capacity labs; ≥80% target)
+#' @param es_data,region,country,year,group_by,end_date Data frame and optional filters: region(s), country(ies), year(s) (single year for starting year or range), grouping (group by = ""), and reference date (default Sys.Date())
+#' @return Grouped tibble with WPV/VDPV detection timeliness, percentage meeting 35- and 46-day targets, and median days to final result as of current month per year
+es_wpv.vdpv_detection_timeliness <- function(es_data, region = NULL, country = NULL, year = NULL, group_by = NULL, end_date = Sys.Date()) {
+  # Apply filters
+  if(!is.null(region)) es_data <- es_data |> dplyr::filter(toupper(trimws(who.region)) %in% toupper(trimws(region)))
+  if(!is.null(country)) es_data <- es_data |> dplyr::filter(toupper(trimws(ADM0_NAME)) %in% toupper(trimws(country)))
+  
+  # Filter for WPV/VDPV positive ES samples first
+  es_data <- es_data |> dplyr::filter(wpv == 1 | vdpv == 1)
+  if(nrow(es_data) == 0) {message("* No WPV/VDPV positive ES samples found for the selected parameters.")
+    return(dplyr::tibble())}
+  
+  # Determine years and filter
+  available_years <- unique(lubridate::year(es_data$collection.date))
+  current_year <- lubridate::year(end_date)
+  years_to_use <- if(!is.null(year)) {
+    intersect(if(length(year) == 1) year:current_year else year, available_years)} else available_years
+  
+  es_data <- es_data |> dplyr::filter(lubridate::year(collection.date) %in% years_to_use)
+  if(nrow(es_data) == 0) {message("* No WPV/VDPV positive ES samples data available for the selected year(s) and location. Change filtering parameters or default to process all available data.")
+    return(dplyr::tibble())}
+  
+  # Data validation and processing
+  total_wpv_vdpv_detected <- nrow(es_data)
+  both_dates_available <- sum(!is.na(es_data$collection.date) & !is.na(es_data$date.final.combined.result))
+  invalid_records <- sum(as.Date(es_data$date.final.combined.result) < as.Date(es_data$collection.date), na.rm = TRUE)
+  
+  valid_data <- es_data |>
+    dplyr::filter(!is.na(collection.date) & !is.na(date.final.combined.result) & 
+                    as.Date(date.final.combined.result) >= as.Date(collection.date)) |>
+    dplyr::mutate(
+      days_to_final_result = as.numeric(as.Date(date.final.combined.result) - as.Date(collection.date)),
+      year = lubridate::year(collection.date),
+      meets_full_capacity_target = days_to_final_result <= 35,
+      meets_limited_capacity_target = days_to_final_result <= 46)
+  
+  wpv_count <- sum(valid_data$wpv == 1, na.rm = TRUE)
+  vdpv_count <- sum(valid_data$vdpv == 1, na.rm = TRUE)
+  both_count <- sum(valid_data$wpv == 1 & valid_data$vdpv == 1, na.rm = TRUE)
+  
+  # Data quality messaging
+  if(total_wpv_vdpv_detected != both_dates_available || invalid_records > 0) {
+    message(paste("* Data quality: Total WPV/VDPV detected for ES samples =", total_wpv_vdpv_detected, 
+                  "| Data with Collection and Final Result dates =", both_dates_available, 
+                  "| Invalid Data (Final Result < Collection) =", invalid_records, 
+                  "|| Valid Data by Type: WPV =", wpv_count, "| VDPV =", vdpv_count, "| Both WPV+VDPV =", both_count))}
+  
+  # Determine grouping
+  group_vars <- if(isTRUE(group_by == "region")) c("who.region", "year") else 
+    if(isTRUE(group_by == "country")) c("who.region", "ADM0_NAME", "year") else 
+      if(!is.null(region) && is.null(group_by)) c("who.region", "year") else 
+        c("who.region", "ADM0_NAME", "year")
+  
+  # Calculate results and median
+  current_month <- lubridate::month(end_date)
+  median_column_name <- paste0("Median Days to Final Result (Jan-", month.abb[current_month], ")")
+  
+  median_df <- valid_data |>
+    dplyr::filter(lubridate::year(collection.date) != current_year |
+                    (lubridate::year(collection.date) == current_year & 
+                       lubridate::month(collection.date) <= current_month)) |>
+    dplyr::group_by(dplyr::across(dplyr::all_of(group_vars))) |>
+    dplyr::summarise(!!median_column_name := round(median(days_to_final_result, na.rm = TRUE), 1), .groups = "drop")
+  
+  result <- valid_data |>
+    dplyr::group_by(dplyr::across(dplyr::all_of(group_vars))) |>
+    dplyr::summarise(
+      total_wpv_vdpv_detected = n(),
+      wpv_detected = sum(wpv == 1, na.rm = TRUE),
+      vdpv_detected = sum(vdpv == 1, na.rm = TRUE),
+      detection_within_35days = sum(meets_full_capacity_target, na.rm = TRUE),
+      pct_full_capacity_lab = round(detection_within_35days / n() * 100, 1),
+      meets_80pct_target_35days = ifelse(pct_full_capacity_lab >= 80, "Yes", "No"),
+      detection_within_46days = sum(meets_limited_capacity_target, na.rm = TRUE),
+      pct_without_full_capacity_lab = round(detection_within_46days / n() * 100, 1),
+      meets_80pct_target_46days = ifelse(pct_without_full_capacity_lab >= 80, "Yes", "No"),
+      detection_beyond_46days = sum(!meets_limited_capacity_target, na.rm = TRUE),
+      pct_beyond_46days = round(detection_beyond_46days / n() * 100, 1),
+      .groups = "keep") |>
+    dplyr::left_join(median_df, by = group_vars) |>
+    dplyr::mutate(year = ifelse(year == current_year, paste0(year, "*"), as.character(year))) |>
+    dplyr::rename_with(~ case_when(. == "who.region" ~ "region", . == "ADM0_NAME" ~ "country", TRUE ~ .))
+  
+  if(current_year %in% years_to_use) message(paste0("* Note: ", current_year, " is still in progress..."))
+  message("* WPV/VDPV detection timeliness (targets: 35 days full capacity, 46 days limited capacity, ≥80% target for both)")
+  result |> print(width = Inf)
+}


### PR DESCRIPTION
To Test:
1. Load required libraries: library(tidyverse), library(readr)
2. Load dataset as `es_data`
3. Dataset needs to contain the following columns: `collection.date`, `date.final.combined.result`, `wpv`, `vdpv`, `who.region`, `ADM0_NAME`
4. Test the function `es_wpv.vdpv_detection_timeliness()`: usage pattern options include default all data (`es_data`) grouped by region and country; single or multiple regions; single or multiple countries; grouping by `“region”` or `“country”`; year filtering (specific period)
5. Check outputs:
- timeliness calculations (days to final result) and the median up to the current month per year
- percentage of samples meeting 35-day (full capacity) and 46-day (limited capacity) targets, including ≥80% target flags, and percentage of samples beyond 46-day (full or limited capacity)
- messages/info indicating missing dates or invalid date sequences