### PR TITLE
Create build_neg_samples_timeliness_indicator.R

### DIFF
--- a/R/build_neg_samples_timeliness_indicator.R
+++ b/R/build_neg_samples_timeliness_indicator.R
@@ -90,6 +90,12 @@ build_negative_samples_timeliness <- function(lab_data, end_date = Sys.Date()) {
 
   # Prepare Data -----
 
+  # create country+culture.itd.category lookup
+  culture_cat_lookup <- lab_data |>
+    dplyr::distinct(country, culture.itd.cat) |>
+    dplyr::filter(!is.na(culture.itd.cat))
+
+  # create indicator lab data
   lab_prep <- lab_data  |>
     dplyr::mutate(
       # Prepare month and year columns
@@ -127,10 +133,11 @@ build_negative_samples_timeliness <- function(lab_data, end_date = Sys.Date()) {
   final_summary <- tidyr::expand_grid(
     country  = unique(lab_prep$country),
     current_combos |> dplyr::select(year, month_num, month)) |>
-    dplyr::left_join(current_counts, by = c("country", "year", "month_num", "month")) |>
+    dplyr::left_join(culture_cat_lookup, by = "country") |>  # bring in stable culture category
+    dplyr::left_join(current_counts, by = c("country", "culture.itd.cat", "year", "month_num", "month")) |>
     dplyr::left_join(
-      prior_counts |> dplyr::select(country, month_num, prior_n, prior_median_days),
-      by = c("country", "month_num")) |>
+      prior_counts |> dplyr::select(country, culture.itd.cat, month_num, prior_n, prior_median_days),
+      by = c("country", "culture.itd.cat", "month_num")) |>
     dplyr::mutate(month_label = paste0(month, " ", year)) |>
     dplyr::select(-year, -month, -month_num) |>
     dplyr::mutate(

--- a/R/build_neg_samples_timeliness_indicator.R
+++ b/R/build_neg_samples_timeliness_indicator.R
@@ -1,0 +1,178 @@
+#' Build Timely Detection of Negative AFP Samples Indicator
+#'
+#' Calculates the median number of days from stool collection to final cell
+#' culture result for negative AFP samples for the current rolling 6-month window.
+#' Each month is compared to the same month in the prior year. Returns results
+#' in long format with one row per country per month.
+#'
+#' @details
+#' Negative samples are defined as those where \code{FinalCellCultureResult}
+#' is in \code{c("Negative", "NPEV", NA, "")}. Timeliness intervals outside
+#' 0-365 days are excluded as likely data quality issues. Case date
+#' (\code{CaseDate}) is used to assign cases to months, and
+#' \code{culture.itd.cat} is retained as a grouping variable for context only.
+#'
+#' @param lab_data A data frame containing lab data. Must include
+#'   \code{CaseDate}, \code{country},
+#'   \code{culture.itd.cat}, \code{DateStoolCollected},
+#'   \code{DateFinalCellCultureResult}, and \code{FinalCellCultureResult}.
+#' @param end_date The maximum date available in the lab dataset. Typically
+#'   passed as \code{max(lab_data$CaseDate, na.rm = TRUE)}.
+#'   Defaults to \code{Sys.Date()}.
+#'
+#' @return A named list with two elements:
+#' \describe{
+#'   \item{data}{A long-format data frame with one row per country per month
+#'     containing: \code{country}, \code{whoregion}, \code{month_label},
+#'     \code{culture.itd.cat}, \code{current_n}, \code{current_median_days},
+#'     \code{prior_n}, \code{prior_median_days}, \code{perc_change},
+#'     and \code{flag}.}
+#'   \item{metadata}{A named list containing: \code{indicator_code},
+#'     \code{indicator_label}, \code{lab_end_date}, \code{eligibility_note},
+#'     \code{current_period_start}, \code{current_period_end},
+#'     \code{current_period_label}, \code{prior_period_label},
+#'     \code{n_current_months}, \code{n_prior_years}, \code{threshold_rule},
+#'     \code{definition}, and \code{possible_statuses}.}
+#' }
+#'
+#' @examples
+#' \dontrun{
+#' max_lab_date <- max(lab_data$CaseDate, na.rm = TRUE)
+#' result <- build_negative_samples_timeliness(lab_data, max_lab_date)
+#' result$data
+#' result$metadata$current_period_label
+#' }
+#'
+#' @export
+build_negative_samples_timeliness <- function(lab_data, end_date = Sys.Date()) {
+
+  # Basic initial checks -----
+  required_cols <- c("CaseDate", "country", "culture.itd.cat",
+                     "DateStoolCollected", "DateFinalCellCultureResult",
+                     "FinalCellCultureResult")
+  stopifnot(
+    "lab_data must be a data frame" = is.data.frame(lab_data),
+    "required columns missing from lab_data" = all(required_cols %in% names(lab_data))
+  )
+
+  # Date Windows -----
+
+  # Ensure end_date is a date type
+  end_date <- lubridate::as_date(end_date)
+  analysis_end <- lubridate::floor_date(end_date,  unit = "month") %m-% days(1)
+  window_start <- lubridate::floor_date(analysis_end %m-% months(5), unit = "month")
+
+  current_months <- seq(window_start, analysis_end, by = "month")
+
+  # create all possible combinations for current 6 months assessment
+  current_combos <- tibble::tibble(
+    year      = lubridate::year(current_months),
+    month_num = lubridate::month(current_months),
+    month     = lubridate::month(current_months, label = TRUE, abbr = TRUE)
+  )
+
+  # create all possible combinations for prior year
+  prior_combos <- dplyr::mutate(current_combos, year = year - 1)
+
+  # Period Labels -----
+  # create labels from dates to export with final data
+  current_period_label <- paste0(format(window_start, "%b %Y"), " - ", format(analysis_end, "%b %Y"))
+  prior_period_label <- paste0(format(window_start %m-% lubridate::years(1), "%b %Y" ), " - ",
+                               format(analysis_end %m-% lubridate::years(1), "%b %Y"))
+
+
+  eligibility_note <- paste0(
+    "Lab data end date: ", format(end_date, "%b %d, %Y"), ". ",
+    "Analysis window is derived from last complete month prior to lab data end date. ",
+    "Lab data may lag behind end date used for AFP indicators."
+  )
+
+
+  # Prepare Data -----
+
+  lab_prep <- lab_data  |>
+    dplyr::mutate(
+      # Prepare month and year columns
+      year = lubridate::year(CaseDate),
+      month_num = lubridate::month(CaseDate),
+      month = lubridate::month(CaseDate, label = TRUE, abbr = TRUE),
+      # Days to collect
+      days_collect_to_result = as.numeric(lubridate::as_date(DateFinalCellCultureResult) - lubridate::as_date(DateStoolCollected))) |>
+    dplyr::filter(
+      !is.na(days_collect_to_result),
+      dplyr::between(days_collect_to_result, 0, 365), # data quality limitation
+      FinalCellCultureResult %in% c("Negative", "NPEV", NA, ""))
+
+
+  # Current Period Counts -----
+  current_counts <- lab_prep |>
+    dplyr::inner_join(current_combos, by = c("year", "month_num", "month")) |>
+    dplyr::group_by(country, culture.itd.cat, year, month_num, month) |>
+    dplyr::summarise(current_n = dplyr::n(),
+                     current_median_days = median(days_collect_to_result, na.rm = TRUE),
+                     .groups = "drop")
+
+
+  # Prior Period Counts -----
+  prior_counts <- lab_prep |>
+    dplyr::inner_join(prior_combos, by = c("year", "month_num", "month")) |>
+    dplyr::group_by(country, culture.itd.cat, month_num, month) |>
+    dplyr::summarise(prior_n = dplyr::n(),
+                     prior_median_days = median(days_collect_to_result, na.rm = TRUE),
+                     .groups = "drop")
+
+
+
+  # Full grid and join for full table -----
+  final_summary <- tidyr::expand_grid(
+    country  = unique(lab_prep$country),
+    current_combos |> dplyr::select(year, month_num, month)) |>
+    dplyr::left_join(current_counts, by = c("country", "year", "month_num", "month")) |>
+    dplyr::left_join(
+      prior_counts |> dplyr::select(country, month_num, prior_n, prior_median_days),
+      by = c("country", "month_num")) |>
+    dplyr::mutate(month_label = paste0(month, " ", year)) |>
+    dplyr::select(-year, -month, -month_num) |>
+    dplyr::mutate(
+      # add region
+      whoregion = sirfunctions::get_region(country),
+      # For counts, NA is to be assumed as 0
+      current_n = tidyr::replace_na(current_n, 0),
+      prior_n = tidyr::replace_na(prior_n, 0),
+      # Create percent change of median
+      perc_change = round((current_median_days - prior_median_days) / prior_median_days * 100),
+      flag = case_when(
+        # missing data — cannot calculate change
+        is.na(perc_change) ~ "Incomplete Data", # handles either or both medians missing
+        # threshold
+        perc_change < -50 ~ "Above Target",
+        perc_change > 50 ~ "Below Target",
+        dplyr::between(perc_change, -50, 50) ~ "Within Target",
+        TRUE ~ "Review")) |>
+    dplyr::select(country, whoregion, month_label, culture.itd.cat, current_n, current_median_days, prior_n, prior_median_days, perc_change, flag)
+
+
+
+  # Return -----
+  meta <- list(
+    indicator_code = "neg_samples_timeliness",
+    indicator_label = "Timely Detection of Negative AFP Samples",
+    lab_end_date = end_date,
+    eligibility_note = eligibility_note,
+    current_period_start = window_start,
+    current_period_end = analysis_end,
+    current_period_label = current_period_label,
+    prior_period_label = prior_period_label,
+    n_current_months = 6,
+    n_prior_years = 1,
+    threshold_rule = "±50% of median of prior year",
+    definition = "",
+    possible_statuses = c("Within Target", "Below Target", "Above Target", "Incomplete Data")
+  )
+
+
+  return(list(
+    data = final_summary,
+    metadata = meta))
+
+}


### PR DESCRIPTION
This PR pushed the changes to refactor the Timely detection of negative AFP samples indicator.

This script is the refactor to include in the indicator script the time periods, new threshold, and flag. The output includes intermediate variables as well as the flag. I also left a count per time period which is not really an intermediate variable but helps gives context.
The time component is changed to each month vs that month in prior year, and shows last 6 months

To follow the script will need to run some lines from the existing (old) generate_data_for_report.R file to get the lab data in -- lines 8&9, 27-43, and 49. Then run: 
`end_date <- max_lab_date`

Closes #139 