### PR TITLE
137 refactor proportion inadequate cases classified

### DIFF
--- a/R/build_prop_inad_classified_indicator.R
+++ b/R/build_prop_inad_classified_indicator.R
@@ -1,12 +1,41 @@
-#' Title
+#' Build Proportion of Inadequate Cases Classified Indicator
 #'
-#' @param afp_data
-#' @param end_date
+#' Calculates the proportion of inadequate AFP cases with onset between 90 and
+#' 365 days ago that have a classification. Returns one row per country.
+#' There is no time comparator.
 #'
-#' @return
-#' @export
+#' @details
+#' A 90-day lag is applied based on case age calculated from \code{end_date}.
+#' Only cases where \code{case_age} falls between 90 and 365 days are
+#' eligible, defined using onset date. This window ensures cases have had
+#' sufficient time to receive a classification and excludes very old cases.
+#'
+#' @param afp_data A data frame containing AFP case-level data. Must include
+#'   \code{dateonset}, \code{place.admin.0}, and \code{cdc.classification.all2}.
+#' @param end_date Date used to calculate case age and define the
+#'   eligible window. Defaults to \code{Sys.Date()}. Typically passed as the
+#'   last day of the previous month.
+#'
+#' @return A named list with two elements:
+#' \describe{
+#'   \item{data}{A data frame with one row per country containing:
+#'     \code{ctry}, \code{whoregion}, \code{inad_cases},
+#'     \code{n_classified}, \code{n_unclassified},
+#'     \code{prop_unclassified}, and \code{flag}.}
+#'   \item{metadata}{A named list containing \code{indicator_code},
+#'     \code{indicator_label}, \code{end_date}, \code{eligibility_start},
+#'     \code{eligibility_end}, \code{eligibility_note}, \code{threshold_rule},
+#'     \code{definition}, and \code{possible_statuses}.}
+#' }
 #'
 #' @examples
+#' \dontrun{
+#' result <- build_prop_inadequate_classified(raw_data$afp, end_date)
+#' result$data
+#' result$metadata$eligibility_note
+#' }
+#'
+#' @export
 build_prop_inadequate_classified <- function(afp_data, end_date = Sys.Date()) {
 
   # Basic initial checks -----
@@ -48,8 +77,8 @@ build_prop_inadequate_classified <- function(afp_data, end_date = Sys.Date()) {
     dplyr::group_by(ctry) |>
     dplyr::summarize(
       inad_cases   = dplyr::n(),
-      n_classified = sum(cdc.classification.all2 != "PENDING", na.rm = TRUE),
-      n_unclassified = sum(cdc.classification.all2 == "PENDING", na.rm = TRUE),
+      n_classified = sum(!cdc.classification.all2 %in% c("PENDING", "LAB PENDING"), na.rm = TRUE),
+      n_unclassified = sum(cdc.classification.all2 %in% c("PENDING", "LAB PENDING"), na.rm = TRUE),
       prop_unclassified   = round(n_unclassified / inad_cases * 100),
       .groups = "drop") |>
     dplyr::mutate(
@@ -65,6 +94,9 @@ build_prop_inadequate_classified <- function(afp_data, end_date = Sys.Date()) {
   meta <- list(
     indicator_code     = "prop_inad_classified",
     indicator_label    = "Proportion of Inadequate Cases Classified",
+    end_date           = end_date,
+    eligibility_start  = start_date,
+    eligibility_end    = end_date - days(90),
     eligibility_note   = eligibility_note,
     threshold_rule     = "Above Target if more than 10% of eligible inadequate cases are unclassified",
     definition         = "",

--- a/R/build_prop_inad_classified_indicator.R
+++ b/R/build_prop_inad_classified_indicator.R
@@ -72,25 +72,39 @@ build_prop_inadequate_classified <- function(afp_data, end_date = Sys.Date()) {
     dplyr::filter(adequacy.final2 == "Inadequate",
                   dplyr::between(case_age, 90, 365))
 
+
   # Summarize per country -----
-  final_summary <- eligible_cases |>
+  summary <- eligible_cases |>
     dplyr::group_by(ctry) |>
     dplyr::summarize(
       inad_cases   = dplyr::n(),
       n_classified = sum(!cdc.classification.all2 %in% c("PENDING", "LAB PENDING"), na.rm = TRUE),
       n_unclassified = sum(cdc.classification.all2 %in% c("PENDING", "LAB PENDING"), na.rm = TRUE),
       prop_unclassified   = round(n_unclassified / inad_cases * 100),
-      .groups = "drop") |>
+      .groups = "drop")
+
+
+  # Create Full Grid of all Countries + Region -----
+  full_grid <- tibble::tibble(
+    ctry = unique(afp_data$place.admin.0)
+  ) |>
+    dplyr::mutate(whoregion = sirfunctions::get_region(ctry))
+
+
+  # Join for full table -----
+  final_summary <- full_grid |>
+    dplyr::left_join(summary, by = "ctry") |>
     dplyr::mutate(
-      # add region
-      whoregion = sirfunctions::get_region(ctry),
       flag = case_when(
-        prop_unclassified <= 10 ~ "Within Target",
-        prop_unclassified > 10 ~ "Above Target",
+        is.na(prop_unclassified) ~ "Incomplete Data", # handles when all data is missing
+        prop_unclassified < 10 ~ "Within Target",
+        prop_unclassified >= 10 ~ "Off Target",
         TRUE ~ "Review")) |>
     dplyr::select(ctry, whoregion, inad_cases, n_classified, n_unclassified,
                   prop_unclassified, flag)
 
+
+  # Return -----
   meta <- list(
     indicator_code     = "prop_inad_classified",
     indicator_label    = "Proportion of Inadequate Cases Classified",
@@ -98,9 +112,9 @@ build_prop_inadequate_classified <- function(afp_data, end_date = Sys.Date()) {
     eligibility_start  = start_date,
     eligibility_end    = end_date - days(90),
     eligibility_note   = eligibility_note,
-    threshold_rule     = "Above Target if more than 10% of eligible inadequate cases are unclassified",
+    threshold_rule     = "Off Target if 10% or more of eligible inadequate cases are unclassified",
     definition         = "",
-    possible_statuses  = c("Within Target", "Above Target")
+    possible_statuses  = c("Within Target", "Off Target", "Incomplete Data")
   )
 
   return(list(

--- a/R/build_prop_inad_classified_indicator.R
+++ b/R/build_prop_inad_classified_indicator.R
@@ -1,0 +1,69 @@
+#' Title
+#'
+#' @param afp_data
+#' @param end_date
+#'
+#' @return
+#' @export
+#'
+#' @examples
+build_prop_inadequate_classified <- function(afp_data, end_date = Sys.Date()) {
+
+  # Basic initial checks -----
+  stopifnot(
+    "afp_data must be a data frame" = is.data.frame(afp_data),
+    "dateonset column required" = "dateonset" %in% names(afp_data),
+    "place.admin.0 column required" = "place.admin.0" %in% names(afp_data)
+  )
+
+  # Date Windows -----
+
+  # Ensure end_date is a date type
+  end_date <- lubridate::as_date(end_date)
+
+  # Recent 3-month window — last complete month
+  recent_end   <- lubridate::floor_date(end_date, unit = "month") %m-% days(1)
+  recent_start <- lubridate::floor_date(recent_end %m-% months(2), unit = "month")
+
+  # Recent 3-month window - one year prior for comparison
+  recent_prior_end   <- recent_end   %m-% lubridate::years(1)
+  recent_prior_start <- recent_start %m-% lubridate::years(1)
+
+  # Period Labels -----
+  recent_period_label  <- paste0(format(recent_start, "%b %Y"), " - ", format(recent_end, "%b %Y"))
+  recent_prior_period_label    <- paste0(format(recent_prior_start, "%b %Y"), " - ", format(recent_prior_end, "%b %Y"))
+
+  # Prepare data from sirfunctions -----
+  # Use recent_prior_start as start date required parameter in functions - will capture data for both periods
+  stool_data <- sirfunctions::generate_stool_data(
+    afp_data,
+    start_date = recent_prior_start,
+    end_date   = recent_end)
+
+  # Filter to eligible inadequate cases only -----
+  eligible_cases <- stool_data |>
+    dplyr::mutate(case_age = as.numeric(difftime(recent_end, date, units = "days"))) |>
+    dplyr::filter(adequacy.final2 == "Inadequate",
+                  case_age > 90)
+
+  # Helper to summarize counts for a given window -----
+  summarize_window <- function(data, start, end) {
+    data |>
+      dplyr::filter(dplyr::between(date, start, end)) |>
+      dplyr::group_by(ctry) |>
+      dplyr::summarize(
+        inad_cases   = dplyr::n(),
+        no_classified = sum(cdc.classification.all2 != "PENDING", na.rm = TRUE),
+        prop_classified   = round(no_classified / inad_cases * 100),
+        .groups = "drop"
+      )
+  }
+
+  # Period Counts -----
+  # Count number pending for each of the four time periods
+  recent_counts        <- summarize_window(eligible_cases, recent_start, recent_end)
+  recent_prior_counts  <- summarize_window(eligible_cases, recent_prior_start, recent_prior_end)
+
+
+
+}

--- a/R/build_prop_inad_classified_indicator.R
+++ b/R/build_prop_inad_classified_indicator.R
@@ -13,57 +13,67 @@ build_prop_inadequate_classified <- function(afp_data, end_date = Sys.Date()) {
   stopifnot(
     "afp_data must be a data frame" = is.data.frame(afp_data),
     "dateonset column required" = "dateonset" %in% names(afp_data),
-    "place.admin.0 column required" = "place.admin.0" %in% names(afp_data)
+    "place.admin.0 column required" = "place.admin.0" %in% names(afp_data),
+    "cdc.classification.all2 column required" = "cdc.classification.all2"  %in% names(afp_data)
   )
 
   # Date Windows -----
 
   # Ensure end_date is a date type
   end_date <- lubridate::as_date(end_date)
+  # Only cases within last 365 days
+  start_date <- end_date - days(365)
 
-  # Recent 3-month window — last complete month
-  recent_end   <- lubridate::floor_date(end_date, unit = "month") %m-% days(1)
-  recent_start <- lubridate::floor_date(recent_end %m-% months(2), unit = "month")
-
-  # Recent 3-month window - one year prior for comparison
-  recent_prior_end   <- recent_end   %m-% lubridate::years(1)
-  recent_prior_start <- recent_start %m-% lubridate::years(1)
-
-  # Period Labels -----
-  recent_period_label  <- paste0(format(recent_start, "%b %Y"), " - ", format(recent_end, "%b %Y"))
-  recent_prior_period_label    <- paste0(format(recent_prior_start, "%b %Y"), " - ", format(recent_prior_end, "%b %Y"))
+  eligibility_note <- paste0(
+    "Eligible cases have onset between ", format(start_date, "%b %d, %Y"),
+    " and ", format(end_date - days(90), "%b %d, %Y"), " (90 to 365 days before ",
+    format(end_date, "%b %d, %Y"), "). ",
+    "The 90-day lag ensures cases have had sufficient time to receive a classification."
+  )
 
   # Prepare data from sirfunctions -----
-  # Use recent_prior_start as start date required parameter in functions - will capture data for both periods
   stool_data <- sirfunctions::generate_stool_data(
     afp_data,
-    start_date = recent_prior_start,
-    end_date   = recent_end)
+    start_date = start_date,
+    end_date   = end_date)
 
   # Filter to eligible inadequate cases only -----
   eligible_cases <- stool_data |>
-    dplyr::mutate(case_age = as.numeric(difftime(recent_end, date, units = "days"))) |>
+    dplyr::mutate(case_age = as.numeric(end_date - lubridate::as_date(date))) |>
     dplyr::filter(adequacy.final2 == "Inadequate",
-                  case_age > 90)
+                  dplyr::between(case_age, 90, 365))
 
-  # Helper to summarize counts for a given window -----
-  summarize_window <- function(data, start, end) {
-    data |>
-      dplyr::filter(dplyr::between(date, start, end)) |>
-      dplyr::group_by(ctry) |>
-      dplyr::summarize(
-        inad_cases   = dplyr::n(),
-        no_classified = sum(cdc.classification.all2 != "PENDING", na.rm = TRUE),
-        prop_classified   = round(no_classified / inad_cases * 100),
-        .groups = "drop"
-      )
+  # Summarize per country -----
+  final_summary <- eligible_cases |>
+    dplyr::group_by(ctry) |>
+    dplyr::summarize(
+      inad_cases   = dplyr::n(),
+      n_classified = sum(cdc.classification.all2 != "PENDING", na.rm = TRUE),
+      n_unclassified = sum(cdc.classification.all2 == "PENDING", na.rm = TRUE),
+      prop_unclassified   = round(n_unclassified / inad_cases * 100),
+      .groups = "drop") |>
+    dplyr::mutate(
+      # add region
+      whoregion = sirfunctions::get_region(ctry),
+      flag = case_when(
+        prop_unclassified <= 10 ~ "Within Target",
+        prop_unclassified > 10 ~ "Above Target",
+        TRUE ~ "Review")) |>
+    dplyr::select(ctry, whoregion, inad_cases, n_classified, n_unclassified,
+                  prop_unclassified, flag)
+
+  meta <- list(
+    indicator_code     = "prop_inad_classified",
+    indicator_label    = "Proportion of Inadequate Cases Classified",
+    eligibility_note   = eligibility_note,
+    threshold_rule     = "Above Target if more than 10% of eligible inadequate cases are unclassified",
+    definition         = "",
+    possible_statuses  = c("Within Target", "Above Target")
+  )
+
+  return(list(
+    data     = final_summary,
+    metadata = meta
+  ))
+
   }
-
-  # Period Counts -----
-  # Count number pending for each of the four time periods
-  recent_counts        <- summarize_window(eligible_cases, recent_start, recent_end)
-  recent_prior_counts  <- summarize_window(eligible_cases, recent_prior_start, recent_prior_end)
-
-
-
-}


### PR DESCRIPTION
This PR pushed the changes for Proportion of Inadequate Cases Classified.

This script is the refactor to include in the indicator script the correct unclassified definition, new threshold, and flag. The new definition includes `LAB PENDING` as well as `PENDING`. The output includes all intermediate variables as well as the flag. 

To follow the script will need to run these lines:

```
end_date <- ceiling_date(Sys.Date() %m-% months(1), unit = "month") %m-% days(1)
raw_data <- get_all_polio_data(attach.spatial.data = FALSE)
afp_data <- raw_data$afp
```

Closes #137 