### PR TITLE
Made changes to lab indicator code eligibility notes to improve clarity

### DIFF
--- a/R/build_lab_workload_indicator.R
+++ b/R/build_lab_workload_indicator.R
@@ -81,7 +81,8 @@ build_lab_workload_indicator <- function(lab_data, end_date = Sys.Date()) {
   )
 
   eligibility_note <- paste0(
-    "Lab data end date: ", format(end_date, "%b %d, %Y"), ". ",
+    "Lab data end date: ", format(end_date, "%b %d, %Y"), ", based on the ",
+    "latest date in POLIS for date stool was received in lab (DateStoolReceivedinLab). ",
     "Analysis window is derived from the last complete month prior to the analysis end date. ",
     "Samples are counted by DateStoolReceivedinLab."
   )

--- a/R/build_timeliness_of_ITD_results_indicator.R
+++ b/R/build_timeliness_of_ITD_results_indicator.R
@@ -102,7 +102,8 @@ build_timeliness_of_ITD_results_indicator <- function(lab_data, end_date = Sys.D
   )
 
   eligibility_note <- paste0(
-    "Lab data end date: ", format(end_date, "%b %d, %Y"), ". ",
+    "Lab data end date: ", format(end_date, "%b %d, %Y"), ", based on the ",
+    "latest date in POLIS for date of final RTPCR results (DateFinalrRTPCRResults). ",
     "Analysis windows are derived from the last complete month prior to lab data end date. ",
     "Samples are assigned to windows by DateFinalrRTPCRResults."
   )

--- a/R/build_timeliness_of_sequencing_results_indicator.R
+++ b/R/build_timeliness_of_sequencing_results_indicator.R
@@ -107,7 +107,8 @@ build_timeliness_of_sequencing_results_indicator <- function(lab_data, end_date 
   )
 
   eligibility_note <- paste0(
-    "Lab data end date: ", format(end_date, "%b %d, %Y"), ". ",
+    "Lab data end date: ", format(end_date, "%b %d, %Y"), ", based on the ",
+    "latest date in POLIS for date of sequencing (DateofSequencing). ",
     "Analysis windows are derived from the last complete month prior to lab data end date. ",
     "Samples are assigned to windows by DateofSequencing."
   )

--- a/R/build_timeliness_of_shipment_for_sequencing_indicator.R
+++ b/R/build_timeliness_of_shipment_for_sequencing_indicator.R
@@ -108,7 +108,8 @@ build_timeliness_of_shipment_for_sequencing_indicator <- function(lab_data,
   )
 
   eligibility_note <- paste0(
-    "Lab data end date: ", format(end_date, "%b %d, %Y"), ". ",
+    "Lab data end date: ", format(end_date, "%b %d, %Y"), ", based on the ",
+    "latest date in POLIS for date Isolate received for sequencing (DateIsolateRcvdForSeq.). ",
     "Analysis windows are derived from the last complete month prior to lab data end date. ",
     "Samples are assigned to windows by DateIsolateRcvdForSeq."
   )

--- a/R/build_timeliness_virus_isolation_indicator.R
+++ b/R/build_timeliness_virus_isolation_indicator.R
@@ -96,7 +96,8 @@ build_timeliness_virus_isolation_indicator <- function(lab_data, end_date = Sys.
   )
 
   eligibility_note <- paste0(
-    "Lab data end date is: ", format(end_date, "%b %d, %Y"), ", based on DateFinalCellCultureResult. ",
+    "Lab data end date is: ", format(end_date, "%b %d, %Y"), ", based on the ",
+    "latest date in POLIS for date of final cell culture result (DateFinalCellCultureResult). ",
     "Analysis window is derived from the last complete month prior to lab data end date. ",
     "Samples are assigned to months by DateFinalCellCultureResult."
   )


### PR DESCRIPTION
updated with description of variables used to determine the end date for the analysis windows. These are located in the "eligibility note" objects of the indicator code/metadata.

Close #179 