### PR TITLE
Update AFP/ES End Date Lag

### DIFF
--- a/R/build_neg_samples_timeliness_indicator.R
+++ b/R/build_neg_samples_timeliness_indicator.R
@@ -59,7 +59,7 @@ build_negative_samples_timeliness_indicator <- function(lab_data, end_date = Sys
 
   # Ensure end_date is a date type
   end_date <- lubridate::as_date(end_date)
-  analysis_end <- lubridate::floor_date(end_date,  unit = "month") %m-% days(1)
+  analysis_end <- end_date
   window_start <- lubridate::floor_date(analysis_end %m-% months(5), unit = "month")
 
   current_months <- seq(window_start, analysis_end, by = "month")
@@ -83,8 +83,8 @@ build_negative_samples_timeliness_indicator <- function(lab_data, end_date = Sys
 
   eligibility_note <- paste0(
     "Lab data end date: ", format(end_date, "%b %d, %Y"), ". ",
-    "Analysis window is derived from last complete month prior to lab data end date. ",
-    "Lab data may lag behind end date used for AFP indicators."
+    "Analysis window ends on the supplied end_date. ",
+    "Callers should pass the desired analysis end date."
   )
 
 

--- a/R/build_timeliness_es_wpv_vdpv_notification_indicator.R
+++ b/R/build_timeliness_es_wpv_vdpv_notification_indicator.R
@@ -66,8 +66,8 @@ build_timeliness_es_wpv_vdpv_notification_indicator <- function(es_data,
   # Ensure end_date is a date type
   end_date <- lubridate::as_date(end_date)
 
-  # Recent 3-month window - last complete month
-  recent_end <- lubridate::floor_date(end_date, unit = "month") %m-% days(1)
+  # Recent 3-month window ending on the supplied end_date
+  recent_end <- end_date
   recent_start <- lubridate::floor_date(recent_end %m-% months(2), unit = "month")
 
   # Recent 3-month window - one year prior for comparison

--- a/R/build_timely_stool_shipment_indicator.R
+++ b/R/build_timely_stool_shipment_indicator.R
@@ -54,7 +54,7 @@ build_timely_stool_shipment_indicator <- function(lab_data, end_date = Sys.Date(
 
   # Date Windows -----
   end_date <- lubridate::as_date(end_date)
-  analysis_end <- lubridate::floor_date(end_date, unit = "month") %m-% days(1)
+  analysis_end <- end_date
   window_start <- lubridate::floor_date(analysis_end %m-% months(5), unit = "month")
 
   current_months <- seq(window_start, analysis_end, by = "month")

--- a/R/build_wpv_vdpv_timely_detection_indicator.R
+++ b/R/build_wpv_vdpv_timely_detection_indicator.R
@@ -61,7 +61,7 @@ build_wpv_vdpv_timeliness_indicator <- function(pos, end_date = Sys.Date()) {
   end_date <- lubridate::as_date(end_date)
 
   # Recent 3-month window — last complete month
-  recent_end <- lubridate::floor_date(end_date, unit = "month") %m-% days(1)
+  recent_end <- end_date # use supplied end_date as the analysis end
   recent_start <- lubridate::floor_date(recent_end %m-% months(2), unit = "month")
 
   # Recent 3-month window - one year prior for comparison


### PR DESCRIPTION
Updated 3 functions to have no end date lag and use recent_end <- end_date or analysis_end <- end_date