### PR TITLE
Add new indicator and summary tables to QMD

### DIFF
--- a/R/create_summary_tables.R
+++ b/R/create_summary_tables.R
@@ -1,0 +1,170 @@
+# these are helpful functions for summarizing the output from the build functions of the indicators
+# they do not need to be public functions or referenced outside of the generate_data_for_report.R code
+
+create_summary_tables_monthly <- function(data, label, country_var_name, flag_values, incomplete_values, latest_month){
+
+  #divide into two quarters for grouping
+  latest_month <- max(lubridate::my(data$month_label))
+  #re-extract the max dates from the text columns of the tables
+  latest_q_end <- latest_month
+  latest_q_start <- lubridate::floor_date(latest_month %m-% months(2), unit = "month")
+  earlier_q_end <- lubridate::floor_date(latest_month %m-% months(3), unit = "month")
+  earlier_q_start <- lubridate::floor_date(latest_month %m-% months(6), unit = "month")
+
+  #get the number of months a country has been flagged for merging into the country-level table
+  num_months_below <- data |>
+    #create a column for quarter
+    dplyr::mutate(period = dplyr::case_when(dplyr::between(lubridate::my(month_label), latest_q_start, latest_q_end) ~ "Current",
+                                            dplyr::between(lubridate::my(month_label), earlier_q_start, earlier_q_end) ~ "Earlier")) |>
+    dplyr::group_by(dplyr::across(dplyr::all_of(c(country_var_name, "period")))) |>
+    #count number of countries that had at least 2 months below target (or whatever designation is used)
+    dplyr::summarise(months_below = sum(flag %in% flag_values), .groups = "drop") |>
+    dplyr::filter(months_below >= 2) |>
+    dplyr::filter(period == "Current")
+
+  #build id_cols dynamically depending on whether sg_priority_level exists in the data
+  #this allows us to use the same function for the lab indicators, which do not contain sg_priority_level
+  if ("sg_priority_level" %in% names(data)) {
+    id_cols_vec <- c("whoregion", "sg_priority_level", country_var_name, "period")
+  } else {
+    id_cols_vec <- c("whoregion", country_var_name, "period")
+  }
+
+  #pivot wider so the columns are the months and merge the number of months below the target
+  summary_table_country <- data |>
+    dplyr::mutate(period = dplyr::case_when(dplyr::between(lubridate::my(month_label), latest_q_start, latest_q_end) ~ "Current",
+                                            dplyr::between(lubridate::my(month_label), earlier_q_start, earlier_q_end) ~ "Earlier"))  |>
+    #filter for now to simplify the table
+    dplyr::filter(period == "Current")|>
+    tidyr::pivot_wider(id_cols = dplyr::all_of(id_cols_vec), values_from = flag, names_from = month_label) |>
+    dplyr::right_join(num_months_below) |>
+    dplyr::rename(Country = dplyr::all_of(country_var_name)) |>
+    dplyr::mutate(Flag = label)
+
+  summary_table_region <- data |>
+    #create a column for quarter
+    dplyr::mutate(period = dplyr::case_when(dplyr::between(lubridate::my(month_label), latest_q_start, latest_q_end) ~ "Current",
+                                            dplyr::between(lubridate::my(month_label), earlier_q_start, earlier_q_end) ~ "Earlier")) |>
+    dplyr::group_by(dplyr::across(dplyr::all_of(c("whoregion", "period", country_var_name)))) |>
+    #count number of countries that had at least 2 months below target (or whatever designation is used)
+    dplyr::summarise(months_below = sum(flag %in% flag_values) >= 2,
+                     #countries that had all 3 months incomplete
+                     num_months_incomplete = sum(flag %in% incomplete_values) == 3,
+                     .groups = "drop_last") |>
+    #count number of countries
+    dplyr::summarise(num_below = sum(months_below),
+                     num_incomplete = sum(num_months_incomplete),
+                     total_n = dplyr::n(),
+                     num_complete = sum(!num_months_incomplete),
+                     #get the list of countries that meet the criteria for below or incomplete
+                     below_countries = list(.data[[country_var_name]][months_below]),
+                     incomplete_countries = list(.data[[country_var_name]][num_months_incomplete]),
+                     .groups = "drop") |>
+    dplyr::mutate(flagname = label,
+                  #remove countries with incomplete data from the denominator
+                  string = paste0(num_below, "/", num_complete, " (", round(num_below/num_complete,2)*100, "%)"),
+                  #make the lists of countries readable
+                  countries_below = purrr::map_chr(below_countries, ~paste(.x, collapse = ", ")),
+                  countries_incomplete = purrr::map_chr(incomplete_countries, ~paste(.x, collapse = ", "))
+    ) |>
+    dplyr::select(whoregion, flagname, string, period, countries_below, countries_incomplete)
+
+  return(list(
+    country_table = summary_table_country,
+    region_table = summary_table_region
+  ))
+}
+
+#separate logic/functions for quarterly indicators
+create_summary_table_quarterly <- function(data, label, country_var_name, period_var, flag_values, incomplete_values){
+  #get the latest month for identifying the latest period
+  latest_month <- max(lubridate::my(substr(dplyr::pull(data, dplyr::all_of(period_var)), 0, 8)))
+
+  #build select_cols dynamically depending on whether sg_priority_level exists in the data
+  #this allows us to use the same function for the lab indicators, which do not contain sg_priority_level
+  if ("sg_priority_level" %in% names(data)) {
+    select_cols_vec <- c("whoregion", "sg_priority_level", country_var_name, "gperiod", period_var)
+  } else {
+    select_cols_vec <- c("whoregion", country_var_name, "gperiod", period_var)
+  }
+
+  #pull out the countries below target for the summary table
+  summary_table_country <- data |>
+    dplyr::mutate(gperiod = dplyr::case_when(lubridate::my(substr(.data[[period_var]], 0, 8)) == latest_month ~ "Current",
+                                             TRUE ~ "Earlier")) |>
+    #filter to countries with values that are flagged
+    dplyr::filter(flag %in% flag_values) |>
+    dplyr::select(dplyr::all_of(select_cols_vec)) |>
+    dplyr::rename(Country = dplyr::all_of(country_var_name),
+                  Months = dplyr::all_of(period_var)) |>
+    dplyr::mutate(Flag = label)
+
+  summary_table_region <- data |>
+    dplyr::mutate(period = dplyr::case_when(lubridate::my(substr(.data[[period_var]], 0, 8)) == latest_month ~ "Current",
+                                            TRUE ~ "Earlier")) |>
+    dplyr::group_by(whoregion, period) |>
+    #count number of countries with flags by region and period
+    dplyr::summarise(num_below = sum(flag %in% flag_values),
+                     num_incomplete = sum(flag %in% incomplete_values),
+                     total_n = dplyr::n(),
+                     #need to get the list of countries that are not meeting the flag
+                     below_countries = list(.data[[country_var_name]][flag %in% flag_values]),
+                     incomplete_countries = list(.data[[country_var_name]][flag %in% incomplete_values]),
+                     .groups = "drop") |>
+    dplyr::mutate(flagname = label,
+                  #remove countries with incomplete data from the denominator
+                  string = paste0(num_below, "/", (total_n-num_incomplete), " (", round(num_below/(total_n-num_incomplete),2)*100, "%)"),
+                  countries_below = purrr::map_chr(below_countries, ~paste(.x, collapse = ", ")),
+                  countries_incomplete = purrr::map_chr(incomplete_countries, ~paste(.x, collapse = ", "))
+    ) |>
+    dplyr::select(whoregion, flagname, string, period, countries_below, countries_incomplete)
+
+  return(list(
+    country_table = summary_table_country,
+    region_table = summary_table_region
+  ))
+}
+
+#there are also 2 indicators that don't have any time periods
+create_summary_table <- function(data, label, country_var_name, flag_values, incomplete_values, raw_value_col){
+
+  #build select_cols dynamically depending on whether sg_priority_level exists in the data
+  #this allows us to use the same function for the lab indicators, which do not contain sg_priority_level
+  if ("sg_priority_level" %in% names(data)) {
+    select_cols_vec <- c("whoregion", "sg_priority_level", country_var_name, raw_value_col)
+  } else {
+    select_cols_vec <- c("whoregion", country_var_name, raw_value_col)
+  }
+
+  summary_table_country <- data |>
+    #filter to countries with values that are flagged
+    dplyr::filter(flag %in% flag_values) |>
+    dplyr::select(dplyr::all_of(select_cols_vec)) |>
+    dplyr::rename(Country = dplyr::all_of(country_var_name),
+                  Pct = dplyr::all_of(raw_value_col)) |>
+    dplyr::mutate(Flag = label)
+
+  summary_table_region <- data |>
+    dplyr::group_by(whoregion) |>
+    dplyr::summarise(num_below = sum(flag %in% flag_values),
+                     num_incomplete = sum(flag %in% incomplete_values),
+                     total_n = dplyr::n(),
+                     #need to get the list of countries that are not meeting the flag
+                     below_countries_list = list(.data[[country_var_name]][flag %in% flag_values]),
+                     incomplete_countries_list = list(.data[[country_var_name]][flag %in% incomplete_values]),
+                     .groups="drop") |>
+    dplyr::mutate(flagname = label,
+                  #remove countries with incomplete data from the denominator
+                  string = paste0(num_below, "/", (total_n-num_incomplete), " (", round(num_below/(total_n-num_incomplete),2)*100, "%)"),
+                  countries_below = purrr::map_chr(below_countries_list, ~paste(.x, collapse = ", ")),
+                  countries_incomplete = purrr::map_chr(incomplete_countries_list, ~paste(.x, collapse = ", ")),
+                  period = "Current"
+    ) |>
+    dplyr::select(whoregion, flagname, string, period, countries_below, countries_incomplete)
+
+  return(list(
+    country_table = summary_table_country,
+    region_table = summary_table_region
+  ))
+}
+

--- a/generate_data_for_report.R
+++ b/generate_data_for_report.R
@@ -165,6 +165,7 @@ afp_prop_lab_pending <- build_prop_lab_pending(raw_data$afp, end_date)
 afp_wpv_vdpv_timeliness <- build_wpv_vdpv_timeliness_indicator(raw_data$pos, end_date)
 afp_neg_samples <- build_negative_samples_timeliness_indicator(lab_data, get_month_end_from_max(max_lab_date))
 afp_timely_stool <- build_timely_stool_shipment_indicator(lab_data, get_month_end_from_max(max_lab_date))
+afp_inadequate_cases <-build_number_of_inadequate_cases(raw_data$afp, end_date)
 
 # Add risk category
 afp_cases_reported$data <- add_risk(afp_cases_reported$data, "place.admin.0")
@@ -174,6 +175,7 @@ afp_prop_lab_pending$data <- add_risk(afp_prop_lab_pending$data, "ctry")
 afp_wpv_vdpv_timeliness$data <- add_risk(afp_wpv_vdpv_timeliness$data, "ctry")
 afp_neg_samples$data <- add_risk(afp_neg_samples$data, "country")
 afp_timely_stool$data <- add_risk(afp_timely_stool$data, "country")
+afp_inadequate_cases$data <-add_risk(afp_inadequate_cases$data, "place.admin.0")
 
 
 # ES Indicators ----
@@ -214,8 +216,8 @@ if(!dir.exists("datatables")){
   dir.create("datatables")
 }
 save(end_date, max_lab_date, afp_cases_reported, afp_prop_60, afp_prop_inad_classified,
-     afp_prop_lab_pending, afp_wpv_vdpv_timeliness, afp_neg_samples,
-     afp_timely_stool, es_active_sites, es_timely_shipment, es_wpv_vdpv_timeliness,
+     afp_prop_lab_pending, afp_wpv_vdpv_timeliness, afp_neg_samples, afp_timely_stool,
+     afp_inadequate_cases, es_active_sites, es_timely_shipment, es_wpv_vdpv_timeliness,
      es_prop_active_sites_collections, lab_virus_isolation_timeliness,
      lab_virus_ITD_results_timeliness, lab_sequencing_shipment_timeliness,
      lab_workload, lab_sequencing_timeliness,

--- a/generate_data_for_report.R
+++ b/generate_data_for_report.R
@@ -152,6 +152,9 @@ add_seq_lab_who_region <- function(data) {
     dplyr::relocate(whoregion, .after = seq.lab)
 }
 
+# Helper functions: create summary tables
+source_pattern("R", "create_summary_tables")
+
 
 # Create Indicator Results ---------------------------------------------------------------------------------------------
 # Saving the full object list so QMD can access $data and $metadata
@@ -177,7 +180,6 @@ afp_neg_samples$data <- add_risk(afp_neg_samples$data, "country")
 afp_timely_stool$data <- add_risk(afp_timely_stool$data, "country")
 afp_inadequate_cases$data <-add_risk(afp_inadequate_cases$data, "place.admin.0")
 
-
 # ES Indicators ----
 # Generate indicator results
 es_active_sites <- build_number_of_active_ES_sites(raw_data$es, end_date)
@@ -190,7 +192,6 @@ es_active_sites$data <- add_risk(es_active_sites$data, "country")
 es_timely_shipment$data <- add_risk(es_timely_shipment$data, "country")
 es_wpv_vdpv_timeliness$data <- add_risk(es_wpv_vdpv_timeliness$data, "country")
 es_prop_active_sites_collections$data <- add_risk(es_prop_active_sites_collections$data, "country")
-
 
 # Lab Indicators ----
 lab_virus_isolation_timeliness <- build_timeliness_virus_isolation_indicator(lab_data, get_month_end_from_max(max_lab_date))
@@ -206,11 +207,83 @@ lab_sequencing_shipment_timeliness$data <- add_culture_itd_lab_who_region(lab_se
 lab_workload$data <- add_culture_itd_lab_who_region(lab_workload$data)
 lab_sequencing_timeliness$data <- add_seq_lab_who_region(lab_sequencing_timeliness$data)
 
+# Summary Tables ----
+
+#uses the functions from create_summary_tables.R
+afp_cases_summary <- create_summary_tables_monthly(afp_cases_reported$data,"01. AFP Cases Reported","place.admin.0","Below Target","Incomplete Data")
+afp_neg_samples_summary <- create_summary_tables_monthly(afp_neg_samples$data,"06. Negative Sample Timeliness","country","Below Target","Incomplete Data")
+afp_stool_timeliness_summary <- create_summary_tables_monthly(afp_timely_stool$data,"07. Stool Shipment Timeliness","country","Below Target","Incomplete Data")
+afp_inad_cases_summary <- create_summary_tables_monthly(afp_inadequate_cases$data,"08. Inadequate Cases","place.admin.0","Below Target","Incomplete Data")
+
+es_prop_active_sites_summary <- create_summary_tables_monthly(es_prop_active_sites_collections$data,"09. Proportion of Active ES Sites with Monthly Collections","country","Below Target","No Current Active ES")
+es_num_active_sites_summary <- create_summary_tables_monthly(es_active_sites$data,"10. Number of Active ES Sites","country","Below Target","No Current Active ES")
+es_timely_shipment_summary <- create_summary_tables_monthly(es_timely_shipment$data,"11. Timeliness of ES Shipment", "country", "Below Target","Incomplete Data")
+
+afp_prop_60_summary <- create_summary_table_quarterly(afp_prop_60$data, "02. Proportion 60-Day Follow-Up Completed", "ctry", "period", "Off Target", "Incomplete Data")
+afp_timely_wpvvdpv_summary <- create_summary_table_quarterly(afp_wpv_vdpv_timeliness$data, "05. Timely AFP WPV/VDPV Detection", "ctry", "current_period", "Below Target", "Incomplete Data")
+es_wpvvdpv_timeliness_summary <- create_summary_table_quarterly(es_wpv_vdpv_timeliness$data, "12. Timely ES WPV/VDPV Notification", "country", "current_period", "Below Target","Incomplete Data")
+
+afp_prop_inad_unclassified_summary<-create_summary_table(afp_prop_inad_classified$data, "03. Proportion Inadequate Cases Unclassified", "ctry","Off Target","Incomplete Data", "prop_unclassified")
+afp_prop_lab_pending_summary<-create_summary_table(afp_prop_lab_pending$data, "04. Proportion Lab Pending", "ctry", "Off Target", "Incomplete Data", "prop_lab_pending")
+
+#smush them together
+region_table <- dplyr::bind_rows(afp_cases_summary$region_table,
+                               afp_prop_60_summary$region_table,
+                               afp_prop_inad_unclassified_summary$region_table,
+                               afp_prop_lab_pending_summary$region_table,
+                               afp_timely_wpvvdpv_summary$region_table,
+                               afp_neg_samples_summary$region_table,
+                               afp_stool_timeliness_summary$region_table,
+                               afp_inad_cases_summary$region_table,
+                               es_prop_active_sites_summary$region_table,
+                               es_num_active_sites_summary$region_table,
+                               es_timely_shipment_summary$region_table,
+                               es_wpvvdpv_timeliness_summary$region_table) |>
+            dplyr::select(whoregion, flagname, string, period, countries_below, countries_incomplete) |>
+            tidyr::pivot_wider(id_cols=c(whoregion, flagname), values_from=c(string, countries_below, countries_incomplete), names_from=period)
+
+country_table_monthly <- dplyr::bind_rows(afp_cases_summary$country_table,
+                                        afp_neg_samples_summary$country_table,
+                                        afp_stool_timeliness_summary$country_table,
+                                        afp_inad_cases_summary$country_table,
+                                        es_prop_active_sites_summary$country_table,
+                                        es_num_active_sites_summary$country_table,
+                                        es_timely_shipment_summary$country_table)
+
+country_table_quarterly <- dplyr::bind_rows(afp_prop_60_summary$country_table,
+                                          es_wpvvdpv_timeliness_summary$country_table,
+                                          afp_timely_wpvvdpv_summary$country_table)
+
+country_table_noperiod <- dplyr::bind_rows(afp_prop_inad_unclassified_summary$country_table,
+                                         afp_prop_lab_pending_summary$country_table)
+
+#lab tables:
+lab_virus_isolation_timeliness_summary <- create_summary_tables_monthly(lab_virus_isolation_timeliness$data, "13. Timeliness of Virus Isolation", "culture.itd.lab", "Below Target","No current virus isolation data")
+lab_workload_summary <- create_summary_tables_monthly(lab_workload$data, "16. Lab Workload", "culture.itd.lab", "Below Target","Incomplete Data")
+
+lab_itd_timeliness_summary <- create_summary_table_quarterly(lab_virus_ITD_results_timeliness$data, "14. Timeliness of ITD results", "culture.itd.lab", "current_period", "Below Target", c("No prior ITD samples", "No current ITD samples"))
+lab_ship_timeliness_summary <- create_summary_table_quarterly(lab_sequencing_shipment_timeliness$data, "15. Timeliness of Shipment for Sequencing", "culture.itd.lab", "current_period", "Below Target", c("No current shipment for sequencing samples", "No shipment for sequencing samples", "No prior shipment for sequencing samples"))
+lab_seq_timeliness_summary <- create_summary_table_quarterly(lab_sequencing_timeliness$data, "17. Timeliness of Sequencing Results", "seq.lab", "current_period", "Below Target", "No current sequenced samples")
+
+lab_region_table <- dplyr::bind_rows(lab_virus_isolation_timeliness_summary$region_table,
+                                   lab_workload_summary$region_table,
+                                   lab_itd_timeliness_summary$region_table,
+                                   lab_ship_timeliness_summary$region_table,
+                                   lab_seq_timeliness_summary$region_table) |>
+                  dplyr::select(whoregion, flagname, string, period, countries_below, countries_incomplete) |>
+                  tidyr::pivot_wider(id_cols=c(whoregion, flagname), values_from=c(string, countries_below, countries_incomplete),names_from=period)
+
+lab_country_table_monthly <- dplyr::bind_rows(lab_virus_isolation_timeliness_summary$country_table,
+                                            lab_workload_summary$country_table)
+
+lab_country_table_quarterly <- dplyr::bind_rows(lab_itd_timeliness_summary$country_table,
+                                              lab_ship_timeliness_summary$country_table,
+                                              lab_seq_timeliness_summary$country_table)
+
 
 
 # Save -------------------------------------------------------------------------------------------------------
 
-# NEED TO ADD
 # Save tables ----
 if(!dir.exists("datatables")){
   dir.create("datatables")
@@ -221,4 +294,6 @@ save(end_date, max_lab_date, afp_cases_reported, afp_prop_60, afp_prop_inad_clas
      es_prop_active_sites_collections, lab_virus_isolation_timeliness,
      lab_virus_ITD_results_timeliness, lab_sequencing_shipment_timeliness,
      lab_workload, lab_sequencing_timeliness,
+     region_table, country_table_monthly, country_table_quarterly, country_table_noperiod,
+     lab_region_table, lab_country_table_monthly, lab_country_table_quarterly,
      file = "datatables/datatables.rda")

--- a/sg_monitoring_report.qmd
+++ b/sg_monitoring_report.qmd
@@ -97,12 +97,351 @@ End date: **`r format(end_date, "%B %d, %Y")`**
 The objective of the monthly SG Monitoring Report is as an early warning for potential disruption in the surveillance system.  
 Monitoring Flags are presented at the country level across AFP, ES, and Lab. 
 
-### Summary Tables - Region
-
-### Summary Tables- Country
 
 :::
 
+## AFP and ES Summary Tables & Visuals
+
+::: panel-tabset
+
+### Summary Table - Region
+
+The total number of countries in the denominator may change between quarters. See individual flag tabs for definition of incomplete/insufficient data.
+
+
+```{r region-summary-table-alt}
+#| echo: false
+
+region_table_alt <- region_table |>
+    dplyr::select(whoregion, flagname, string_Earlier, string_Current, countries_below_Current, countries_incomplete_Current) |>
+    dplyr::arrange(whoregion, flagname) |>
+    dplyr::rename(
+      Region = whoregion,
+      Flag=flagname,
+      `% of Countries Flagged - Earlier` = string_Earlier,
+      `% of Countries Flagged` = string_Current,
+      `Countries Flagged` = countries_below_Current,
+      `Countries with insufficient data` = countries_incomplete_Current,
+    ) |>
+  #need to create a unique row for dynamic filtering
+  dplyr::mutate(row_key = paste0(Region, "_", Flag)) |>
+  SharedData$new(key = ~row_key)
+
+
+filter_select("region-table", "Region: ", 
+              region_table_alt,
+              ~Region,
+              multiple = FALSE,
+              allLevels = FALSE)
+
+datatable(
+  region_table_alt, 
+  filter = "top",
+  extensions = 'Buttons',
+  rownames=FALSE,
+  options = list(
+    dom = 'Bfrtip',
+    buttons = c('copy', 'csv', 'excel'),
+    pageLength = 12,
+    #need to remove the row_key column we created for dynamic filtering
+    columnDefs = list(
+      list(visible = FALSE, targets = which(names(region_table_alt$data()) == "row_key") - 1)
+    )
+  )
+)
+
+```
+
+### Flagged Countries, Monthly Flags
+
+```{r country-summary-table-m}
+#| echo: false
+
+country_table_m<-country_table_monthly     |>
+    dplyr::select(Flag, whoregion,Country,sg_priority_level,dplyr::matches("[0-9]"),months_below) |>
+    dplyr::rename(
+      Region = whoregion,
+      `SG Priority Level`=sg_priority_level,
+      `Months Below Target` = months_below,
+    )|>
+  #need to create a unique row for dynamic filtering
+  dplyr::mutate(row_key = paste0(Country, "_", Flag)) |>
+  SharedData$new(key = ~row_key)
+
+filter_select("country-table-m-region", "Region: ", 
+              country_table_m,
+              ~Region,
+              multiple = FALSE,
+              allLevels = FALSE)
+
+filter_select("country-table-m-flag", "Flag: ", 
+              country_table_m,
+              ~Flag,
+              multiple = FALSE,
+              allLevels = FALSE)
+
+datatable(
+  country_table_m, 
+  filter = "top",
+  extensions = 'Buttons',
+  rownames=FALSE,
+  options = list(
+    dom = 'Bfrtip',
+    buttons = c('copy', 'csv', 'excel'),
+    pageLength = 20,
+    #need to remove the row_key column we created for dynamic filtering
+    columnDefs = list(
+      list(visible = FALSE, targets = which(names(country_table_m$data()) == "row_key") - 1)
+    )
+  )
+)
+
+
+```
+
+### Flagged Countries, Quarterly Flags
+
+```{r country-summary-table-q}
+#| echo: false
+
+country_table_q<-country_table_quarterly    |>
+    dplyr::select(Flag,whoregion,Country,sg_priority_level,Months) |>
+    dplyr::rename(
+      Region = whoregion,
+      `SG Priority Level`=sg_priority_level    )|>
+  #need to create a unique row for dynamic filtering
+  dplyr::mutate(row_key = paste0(Country, "_", Flag)) |>
+  SharedData$new(key = ~row_key)
+
+filter_select("country-table-q-region", "Region: ", 
+              country_table_q,
+              ~Region,
+              multiple = FALSE,
+              allLevels = FALSE)
+
+filter_select("country-table-q-flag", "Flag: ", 
+              country_table_q,
+              ~Flag,
+              multiple = FALSE,
+              allLevels = FALSE)
+
+datatable(
+  country_table_q, 
+  filter = "top",
+  extensions = 'Buttons',
+  rownames=FALSE,
+  options = list(
+    dom = 'Bfrtip',
+    buttons = c('copy', 'csv', 'excel'),
+    pageLength = 20,
+    #need to remove the row_key column we created for dynamic filtering
+    columnDefs = list(
+      list(visible = FALSE, targets = which(names(country_table_q$data()) == "row_key") - 1)
+    )
+  )
+)
+
+
+```
+
+### Flagged Countries, Flags with other time windows
+
+See individual flag tabs for specific time window.
+
+```{r country-summary-table-n}
+#| echo: false
+
+country_table_n<-country_table_noperiod    |>
+    dplyr::select(Flag, whoregion, Country, sg_priority_level, Pct) |>
+    dplyr::rename(
+      Region = whoregion,
+      `SG Priority Level`=sg_priority_level,
+      `Proportion`=Pct
+    )|>
+  #need to create a unique row for dynamic filtering
+  dplyr::mutate(row_key = paste0(Country, "_", Flag)) |>
+  SharedData$new(key = ~row_key)
+
+filter_select("country-table-n-region", "Region: ", 
+              country_table_n,
+              ~Region,
+              multiple = FALSE,
+              allLevels = FALSE)
+
+filter_select("country-table-n-flag", "Flag: ", 
+              country_table_n,
+              ~Flag,
+              multiple = FALSE,
+              allLevels = FALSE)
+
+datatable(
+  country_table_n, 
+  filter = "top",
+  extensions = 'Buttons',
+  rownames=FALSE,
+  options = list(
+    dom = 'Bfrtip',
+    buttons = c('copy', 'csv', 'excel'),
+    pageLength = 20,
+    #need to remove the row_key column we created for dynamic filtering
+    columnDefs = list(
+      list(visible = FALSE, targets = which(names(country_table_n$data()) == "row_key") - 1)
+    )
+  )
+)
+
+
+```
+
+:::
+
+
+## Lab Summary Tables & Visuals
+
+::: panel-tabset
+
+### Lab Summary Table - Region
+
+The total number of labs in the denominator may change between quarters. See individual flag tabs for definition of incomplete/insufficient data.
+Labs are assigned to WHO regions based on location.
+
+```{r lab-region-summary-table}
+#| echo: false
+
+lab_region_table_wide <- lab_region_table |>
+    dplyr::select(whoregion, flagname, string_Earlier, string_Current, countries_below_Current, countries_incomplete_Current) |>
+    dplyr::arrange(whoregion, flagname) |>
+    dplyr::rename(
+      Region = whoregion,
+      Flag=flagname,
+      `% of Labs Flagged - Earlier` = string_Earlier,
+      `% of Labs Flagged` = string_Current,
+      `Labs Flagged` = countries_below_Current,
+      `Labs with insufficient data` = countries_incomplete_Current,
+    ) |>
+  #need to create a unique row for dynamic filtering
+  dplyr::mutate(row_key = paste0(Region, "_", Flag)) |>
+  SharedData$new(key = ~row_key)
+
+
+filter_select("lab-region-table", "Region: ", 
+              lab_region_table_wide,
+              ~Region,
+              multiple = FALSE,
+              allLevels = FALSE)
+
+datatable(
+  lab_region_table_wide, 
+  filter = "top",
+  extensions = 'Buttons',
+  rownames=FALSE,
+  options = list(
+    dom = 'Bfrtip',
+    buttons = c('copy', 'csv', 'excel'),
+    pageLength = 12,
+    #need to remove the row_key column we created for dynamic filtering
+    columnDefs = list(
+      list(visible = FALSE, targets = which(names(lab_region_table_wide$data()) == "row_key") - 1)
+    )
+  )
+)
+
+```
+
+
+### Flagged Labs, Monthly Flags
+
+```{r lab-country-summary-table-m}
+#| echo: false
+
+lab_country_table_monthly<-lab_country_table_monthly     |>
+    dplyr::select(Flag, whoregion, Country, dplyr::matches("[0-9]"),months_below) |>
+    dplyr::rename(
+      Region = whoregion,
+      Lab = Country,
+      `Months Below Target` = months_below
+    )|>
+  #need to create a unique row for dynamic filtering
+  dplyr::mutate(row_key = paste0(Lab, "_", Flag)) |>
+  SharedData$new(key = ~row_key)
+
+filter_select("lab-country-table-m-region", "Region: ", 
+              lab_country_table_monthly,
+              ~Region,
+              multiple = FALSE,
+              allLevels = FALSE)
+
+filter_select("lab-country-table-m-flag", "Flag: ", 
+              lab_country_table_monthly,
+              ~Flag,
+              multiple = FALSE,
+              allLevels = FALSE)
+
+datatable(
+  lab_country_table_monthly, 
+  filter = "top",
+  extensions = 'Buttons',
+  rownames=FALSE,
+  options = list(
+    dom = 'Bfrtip',
+    buttons = c('copy', 'csv', 'excel'),
+    pageLength = 20,
+    #need to remove the row_key column we created for dynamic filtering
+    columnDefs = list(
+      list(visible = FALSE, targets = which(names(lab_country_table_monthly$data()) == "row_key") - 1)
+    )
+  )
+)
+
+
+```
+
+### Flagged Labs, Quarterly Flags
+
+```{r lab-country-summary-table-q}
+#| echo: false
+
+lab_country_table_quarterly<-lab_country_table_quarterly    |>
+    dplyr::select(Flag, whoregion, Country, Months) |>
+    dplyr::rename(
+      Region = whoregion,
+      Lab=Country)|>
+  #need to create a unique row for dynamic filtering
+  dplyr::mutate(row_key = paste0(Lab, "_", Flag)) |>
+  SharedData$new(key = ~row_key)
+
+filter_select("lab-country-table-q-region", "Region: ", 
+              lab_country_table_quarterly,
+              ~Region,
+              multiple = FALSE,
+              allLevels = FALSE)
+
+filter_select("lab-country-table-q-flag", "Flag: ", 
+              lab_country_table_quarterly,
+              ~Flag,
+              multiple = FALSE,
+              allLevels = FALSE)
+
+datatable(
+  lab_country_table_quarterly, 
+  filter = "top",
+  extensions = 'Buttons',
+  rownames=FALSE,
+  options = list(
+    dom = 'Bfrtip',
+    buttons = c('copy', 'csv', 'excel'),
+    pageLength = 20,
+    #need to remove the row_key column we created for dynamic filtering
+    columnDefs = list(
+      list(visible = FALSE, targets = which(names(lab_country_table_quarterly$data()) == "row_key") - 1)
+    )
+  )
+)
+
+
+```
+
+:::
 
 ## AFP Monitoring Flags
 
@@ -322,7 +661,7 @@ afp_timely_stool$data |>
 
 ### Number of Inadequate Cases
 
-**Definition:**  `r afp_inadequate_cases$metadata$definition`
+**Definition:**  `r afp_inadequate_cases$metadata$definition`  
 **Period of focus:** `r afp_inadequate_cases$metadata$current_period_label`  
 **Comparison periods:** `r afp_inadequate_cases$metadata$prior_period_label`  
 **Threshold for above or below target:** `r afp_inadequate_cases$metadata$threshold_rule`  
@@ -646,3 +985,64 @@ datatable(
 
 :::
 
+```{js enable-js-graphs}
+//| echo: false
+
+function remove_all_option() {
+    document.getElementById("region-table").getElementsByClassName("selectized")[0].selectize.removeOption("");
+    document.getElementById("country-table-m-region").getElementsByClassName("selectized")[0].selectize.removeOption("");
+    document.getElementById("country-table-m-flag").getElementsByClassName("selectized")[0].selectize.removeOption("");
+    document.getElementById("country-table-q-region").getElementsByClassName("selectized")[0].selectize.removeOption("");
+    document.getElementById("country-table-q-flag").getElementsByClassName("selectized")[0].selectize.removeOption("");
+    document.getElementById("country-table-n-region").getElementsByClassName("selectized")[0].selectize.removeOption("");
+    document.getElementById("country-table-n-flag").getElementsByClassName("selectized")[0].selectize.removeOption("");
+    
+    document.getElementById("lab-region-table").getElementsByClassName("selectized")[0].selectize.removeOption("");
+    document.getElementById("lab-country-table-m-region").getElementsByClassName("selectized")[0].selectize.removeOption("");
+    document.getElementById("lab-country-table-m-flag").getElementsByClassName("selectized")[0].selectize.removeOption("");
+    document.getElementById("lab-country-table-q-region").getElementsByClassName("selectized")[0].selectize.removeOption("");
+    document.getElementById("lab-country-table-q-flag").getElementsByClassName("selectized")[0].selectize.removeOption("");
+}
+
+function filter_default() {
+    document.getElementById("region-table").getElementsByClassName("selectized")[0].selectize.setValue("AFRO");
+    
+    document.getElementById("country-table-m-region").getElementsByClassName("selectized")[0].selectize.setValue("AFRO");
+    document.getElementById("country-table-m-flag").getElementsByClassName("selectized")[0].selectize.setValue("01. AFP Cases Reported");
+    document.getElementById("country-table-q-region").getElementsByClassName("selectized")[0].selectize.setValue("AFRO");
+    document.getElementById("country-table-q-flag").getElementsByClassName("selectized")[0].selectize.setValue("02. Proportion 60-Day Follow-Up Completed");
+    document.getElementById("country-table-n-region").getElementsByClassName("selectized")[0].selectize.setValue("AFRO");
+    document.getElementById("country-table-n-flag").getElementsByClassName("selectized")[0].selectize.setValue("03. Proportion Inadequate Cases Unclassified");
+    
+        document.getElementById("lab-region-table").getElementsByClassName("selectized")[0].selectize.setValue("AFRO");
+
+    document.getElementById("lab-country-table-m-region").getElementsByClassName("selectized")[0].selectize.setValue("AFRO");
+    document.getElementById("lab-country-table-m-flag").getElementsByClassName("selectized")[0].selectize.setValue("13. Timeliness of Virus Isolation");
+    document.getElementById("lab-country-table-q-region").getElementsByClassName("selectized")[0].selectize.setValue("AFRO");
+    document.getElementById("lab-country-table-q-flag").getElementsByClassName("selectized")[0].selectize.setValue("14. Timeliness of ITD results");
+    
+    
+}
+function waitForSelectize(callback, maxTries = 50) {
+    let tries = 0;
+    const check = setInterval(function() {
+        tries++;
+        const el = document.getElementById("region-table");
+        if (el && el.getElementsByClassName("selectized")[0] && el.getElementsByClassName("selectized")[0].selectize) {
+            clearInterval(check);
+            callback();
+        } else if (tries >= maxTries) {
+            clearInterval(check);
+            console.warn("Selectize widgets not found after waiting.");
+        }
+    }, 100);
+}
+
+window.onload = function() {
+    waitForSelectize(function() {
+        remove_all_option();
+        filter_default();
+    });
+}
+
+```

--- a/sg_monitoring_report.qmd
+++ b/sg_monitoring_report.qmd
@@ -110,11 +110,9 @@ Monitoring Flags are presented at the country level across AFP, ES, and Lab.
 
 ### Number of AFP Cases Reported
 
-**Definition:**  
 **Period of focus:** `r afp_cases_reported$metadata$current_period_label`  
 **Comparison periods:** `r afp_cases_reported$metadata$prior_period_label`  
 **Threshold for above or below target:** `r afp_cases_reported$metadata$threshold_rule`  
-**Interpretation:**
 
 ```{r afp-cases-table}
 afp_cases_reported$data |>
@@ -320,6 +318,33 @@ afp_timely_stool$data |>
   make_sortable_month_col()
 
 ```
+
+
+### Number of Inadequate Cases
+
+**Definition:**  `r afp_inadequate_cases$metadata$definition`
+**Period of focus:** `r afp_inadequate_cases$metadata$current_period_label`  
+**Comparison periods:** `r afp_inadequate_cases$metadata$prior_period_label`  
+**Threshold for above or below target:** `r afp_inadequate_cases$metadata$threshold_rule`  
+
+```{r inadequate-cases-table}
+afp_inadequate_cases$data |>
+    dplyr::arrange(place.admin.0, lubridate::my(month_label)) |>
+    dplyr::rename(
+      Country = place.admin.0,
+      Region = whoregion,
+      `SG Priority Level` = sg_priority_level,
+      Month = month_label,
+      Cases = current_period_counts,
+      `3yr Median` = prior_3yr_median,
+      `Yrs w/ Data` = prior_yrs_w_data,
+      `Percent Change` = perc_change,
+      Flag = flag
+    ) |>
+  make_sortable_month_col()
+
+```
+
 
 :::
 


### PR DESCRIPTION
This update adds the summary tables to the QMD. The tables are created using the outputs of the `build_`* functions (and other helper functions) within the `generate_data_for_report.R` script.

To test: open `sg_monitoring_report.qmd` in RStudio and click "Render" from the top bar. Review the summary table tabs to make sure they appear as expected, make sure the filters all include a default value and function as expected.

I tested what the report would look like during the August run by setting the `end_date` back only 1 month instead of 2. When the `end_date` set in `sg_monitoring_report.qmd` does not line up with the `max_lab_date` in the `generate_data_for_report.R`, the Flagged Countries summary table will contain different time periods for different indicators, because 2 monthly AFP indicators rely on lab data (negative sample timeliness, stool shipment timeliness).

Note: will eventually need to fix the display of "(NaN%)" when 0 countries/labs have valid data for a period.